### PR TITLE
fix: handle-uninstalled-labbicons-pckg-and-unresolved-icons

### DIFF
--- a/extras/icons/labbicons/templates/cotton/lbi/index.html
+++ b/extras/icons/labbicons/templates/cotton/lbi/index.html
@@ -1,5 +1,6 @@
+{% load lb_tags %}
 <c-vars n w h />
 
-{% if n %}
+{% if n|lb_icon_exists %}
     <c-component is="lbi.{{ n }}" w="{{ w }}" h="{{ h }}" {{ attrs }} />
 {% endif %}

--- a/labb/templatetags/lb_tags.py
+++ b/labb/templatetags/lb_tags.py
@@ -1,13 +1,18 @@
 import json
+import logging
 import re
 from functools import lru_cache
 from pathlib import Path
 from threading import local
 
 from django import template
+from django.apps import apps
+from django.conf import settings
 from django.contrib.staticfiles import finders
 from django.core.signals import request_finished
 from django.dispatch import receiver
+from django.template import TemplateDoesNotExist
+from django.template.loader import get_template
 from django.templatetags.static import static as django_static
 from django.urls import NoReverseMatch, reverse
 from django.utils.safestring import mark_safe
@@ -15,6 +20,8 @@ from django.utils.safestring import mark_safe
 from labb.config import load_config
 from labb.django_settings import get_default_theme, get_labb_setting
 from labb.shortcuts import get_labb_theme
+
+_icon_logger = logging.getLogger("labb.icons")
 
 register = template.Library()
 
@@ -483,6 +490,47 @@ def strip_icon_attrs(attrs):
     # Clean up whitespace
     s = re.sub(r"\s+", " ", s).strip()
     return mark_safe(s)
+
+
+@register.filter
+def lb_icon_exists(name):
+    """
+    Return True if the named labbicons icon template exists and labbicons is installed.
+
+    Returns False (with a warning logged) when:
+    - name is empty or falsy
+    - labbicons is not in INSTALLED_APPS
+    - the icon template does not exist
+
+    Usage: {% if i.name|lb_icon_exists %}
+    """
+    if not name:
+        return False
+
+    cotton_dir = getattr(settings, "COTTON_DIR", "cotton")
+    # Match cotton's path resolution: dots → slashes, hyphens → underscores (when COTTON_SNAKE_CASED_NAMES is True)
+    icon_tpl_path = str(name).replace(".", "/")
+    if getattr(settings, "COTTON_SNAKE_CASED_NAMES", True):
+        icon_tpl_path = icon_tpl_path.replace("-", "_")
+    icon_path = f"{cotton_dir}/lbi/{icon_tpl_path}.html"
+
+    try:
+        get_template(icon_path)
+        return True
+    except TemplateDoesNotExist:
+        if not apps.is_installed("labbicons"):
+            _icon_logger.warning(
+                'Icon "%s" requested but labbicons is not installed. '
+                'Install labbicons and add "labbicons" to '
+                "INSTALLED_APPS to use icons.",
+                name,
+            )
+        else:
+            _icon_logger.warning(
+                'Icon "%s" not found in labbicons. Check the icon name is correct.',
+                name,
+            )
+        return False
 
 
 @register.simple_tag

--- a/labb/templatetags/lb_tags.py
+++ b/labb/templatetags/lb_tags.py
@@ -519,17 +519,19 @@ def lb_icon_exists(name):
         return True
     except TemplateDoesNotExist:
         if not apps.is_installed("labbicons"):
-            _icon_logger.warning(
-                'Icon "%s" requested but labbicons is not installed. '
-                'Install labbicons and add "labbicons" to '
-                "INSTALLED_APPS to use icons.",
-                name,
+            msg = (
+                f'Icon "{name}" requested but labbicons is not installed. '
+                'Add "labbicons" to INSTALLED_APPS to use icons.'
             )
         else:
-            _icon_logger.warning(
-                'Icon "%s" not found in labbicons. Check the icon name is correct.',
-                name,
+            msg = (
+                f'Icon "{name}" not found in labbicons. Check the icon name is correct.'
             )
+
+        if settings.DEBUG:
+            raise ValueError(msg) from None
+
+        _icon_logger.warning(msg)
         return False
 
 

--- a/labb/tests/components/test_icon_rendering.py
+++ b/labb/tests/components/test_icon_rendering.py
@@ -1,15 +1,8 @@
 """
-Tests for icon rendering error handling.
-
-Covers two failure modes:
-  1. Icon name that doesn't exist in labbicons
-  2. labbicons not installed (simulated by mocking get_template)
-
-NOTE: Rendering-based tests must be defined BEFORE pure unit tests in this file.
-Django's template engine is initialized lazily on first use; render_component adds
-the temp dir to settings before the first render_to_string call, which is how the
-engine picks it up.  Any test that calls Template() or get_template() before a
-render_component call would initialize the engine without that temp dir, breaking
+NOTE: Rendering tests must come before unit tests in this file.
+Django's template engine initialises lazily; render_component registers the
+temp dir before the first render_to_string call. Any test that calls
+get_template() first would initialise the engine without that dir, breaking
 all subsequent render_component calls.
 """
 
@@ -24,28 +17,18 @@ from labb.templatetags.lb_tags import lb_icon_exists
 
 from .test_base import ComponentTestBase
 
-# ---------------------------------------------------------------------------
-# Rendering integration tests (must come first — see module docstring)
-# ---------------------------------------------------------------------------
-
 
 class TestIconRenderingGracefulDegradation(ComponentTestBase):
-    """Production (DEBUG=False) rendering: bad icon names must not crash the component."""
-
     @override_settings(DEBUG=False)
     def test_button_with_valid_icon_renders_svg(self):
-        """A button with a valid icon name renders the SVG."""
         html = self.render_component(
-            "button",
-            slot_content="Click me",
-            **{"icon": "rmx.heart"},
+            "button", slot_content="Click me", **{"icon": "rmx.heart"}
         )
         assert "<button" in html
         assert "<svg" in html
 
     @override_settings(DEBUG=False)
     def test_button_with_nonexistent_icon_renders_without_crash(self):
-        """Production: bad icon name renders the button; the icon is silently skipped."""
         html = self.render_component(
             "button",
             slot_content="Click me",
@@ -78,7 +61,6 @@ class TestIconRenderingGracefulDegradation(ComponentTestBase):
 
     @override_settings(DEBUG=False)
     def test_nonexistent_icon_does_not_raise_type_error(self):
-        """The cryptic 'cannot unpack non-iterable NoneType object' must not surface."""
         html = self.render_component(
             "button",
             slot_content="X",
@@ -89,26 +71,17 @@ class TestIconRenderingGracefulDegradation(ComponentTestBase):
 
     @override_settings(DEBUG=True)
     def test_button_with_nonexistent_icon_raises_in_debug(self):
-        """DEBUG=True: rendering a button with a bad icon surfaces a clear ValueError."""
         html = self.render_component(
             "button",
             slot_content="Click me",
             **{"icon": "rmx.this_icon_does_not_exist_xyz"},
         )
-        # render_component catches all exceptions and returns an HTML comment
         assert "Component rendering error" in html
         assert "rmx.this_icon_does_not_exist_xyz" in html
         assert "TypeError" not in html
 
 
-# ---------------------------------------------------------------------------
-# lb_icon_exists filter unit tests
-# ---------------------------------------------------------------------------
-
-
 class TestLbIconExistsFilter:
-    """Unit tests for the lb_icon_exists filter (called as a plain Python function)."""
-
     def test_valid_icon_returns_true(self):
         assert lb_icon_exists("rmx.heart") is True
 
@@ -124,7 +97,6 @@ class TestLbIconExistsFilter:
 
     @override_settings(DEBUG=False)
     def test_missing_template_returns_false(self):
-        """When get_template raises TemplateDoesNotExist, filter returns False."""
         with patch(
             "labb.templatetags.lb_tags.get_template",
             side_effect=TemplateDoesNotExist("cotton/lbi/rmx/heart.html"),
@@ -133,7 +105,6 @@ class TestLbIconExistsFilter:
 
     @override_settings(DEBUG=False)
     def test_missing_template_logs_warning(self, caplog):
-        """A missing icon logs a labb.icons warning instead of crashing."""
         with caplog.at_level(logging.WARNING, logger="labb.icons"):
             with patch(
                 "labb.templatetags.lb_tags.get_template",
@@ -144,7 +115,6 @@ class TestLbIconExistsFilter:
 
     @override_settings(DEBUG=False)
     def test_labbicons_not_installed_logs_different_warning(self, caplog):
-        """When labbicons is not installed, the warning mentions the package."""
         with caplog.at_level(logging.WARNING, logger="labb.icons"):
             with patch(
                 "labb.templatetags.lb_tags.get_template",
@@ -159,13 +129,11 @@ class TestLbIconExistsFilter:
 
     @override_settings(DEBUG=True)
     def test_nonexistent_icon_raises_value_error_in_debug(self):
-        """DEBUG=True: a bad icon name raises ValueError with a clear message."""
         with pytest.raises(ValueError, match="rmx.this_icon_does_not_exist_xyz"):
             lb_icon_exists("rmx.this_icon_does_not_exist_xyz")
 
     @override_settings(DEBUG=True)
     def test_missing_template_raises_value_error_in_debug(self):
-        """DEBUG=True: when get_template raises TemplateDoesNotExist, ValueError is raised."""
         with patch(
             "labb.templatetags.lb_tags.get_template",
             side_effect=TemplateDoesNotExist("cotton/lbi/rmx/heart.html"),
@@ -175,7 +143,6 @@ class TestLbIconExistsFilter:
 
     @override_settings(DEBUG=True)
     def test_labbicons_not_installed_raises_with_install_hint_in_debug(self):
-        """DEBUG=True + labbicons missing: ValueError message mentions INSTALLED_APPS."""
         with patch(
             "labb.templatetags.lb_tags.get_template",
             side_effect=TemplateDoesNotExist("cotton/lbi/rmx/heart.html"),

--- a/labb/tests/components/test_icon_rendering.py
+++ b/labb/tests/components/test_icon_rendering.py
@@ -16,7 +16,9 @@ all subsequent render_component calls.
 import logging
 from unittest.mock import patch
 
+import pytest
 from django.template import TemplateDoesNotExist
+from django.test import override_settings
 
 from labb.templatetags.lb_tags import lb_icon_exists
 
@@ -28,8 +30,9 @@ from .test_base import ComponentTestBase
 
 
 class TestIconRenderingGracefulDegradation(ComponentTestBase):
-    """Integration tests: components with bad icon names must not raise cryptic errors."""
+    """Production (DEBUG=False) rendering: bad icon names must not crash the component."""
 
+    @override_settings(DEBUG=False)
     def test_button_with_valid_icon_renders_svg(self):
         """A button with a valid icon name renders the SVG."""
         html = self.render_component(
@@ -40,8 +43,9 @@ class TestIconRenderingGracefulDegradation(ComponentTestBase):
         assert "<button" in html
         assert "<svg" in html
 
+    @override_settings(DEBUG=False)
     def test_button_with_nonexistent_icon_renders_without_crash(self):
-        """A button with a bad icon name renders the button; the icon is silently skipped."""
+        """Production: bad icon name renders the button; the icon is silently skipped."""
         html = self.render_component(
             "button",
             slot_content="Click me",
@@ -51,6 +55,7 @@ class TestIconRenderingGracefulDegradation(ComponentTestBase):
         assert "Click me" in html
         assert "<svg" not in html
 
+    @override_settings(DEBUG=False)
     def test_alert_with_nonexistent_icon_renders_without_crash(self):
         html = self.render_component(
             "alert",
@@ -61,6 +66,7 @@ class TestIconRenderingGracefulDegradation(ComponentTestBase):
         assert "Something happened" in html
         assert "<svg" not in html
 
+    @override_settings(DEBUG=False)
     def test_kbd_with_nonexistent_icon_renders_without_crash(self):
         html = self.render_component(
             "kbd",
@@ -70,6 +76,7 @@ class TestIconRenderingGracefulDegradation(ComponentTestBase):
         assert "<kbd" in html
         assert "<svg" not in html
 
+    @override_settings(DEBUG=False)
     def test_nonexistent_icon_does_not_raise_type_error(self):
         """The cryptic 'cannot unpack non-iterable NoneType object' must not surface."""
         html = self.render_component(
@@ -78,6 +85,19 @@ class TestIconRenderingGracefulDegradation(ComponentTestBase):
             **{"icon": "rmx.this_icon_does_not_exist_xyz"},
         )
         assert "cannot unpack non-iterable NoneType" not in html
+        assert "TypeError" not in html
+
+    @override_settings(DEBUG=True)
+    def test_button_with_nonexistent_icon_raises_in_debug(self):
+        """DEBUG=True: rendering a button with a bad icon surfaces a clear ValueError."""
+        html = self.render_component(
+            "button",
+            slot_content="Click me",
+            **{"icon": "rmx.this_icon_does_not_exist_xyz"},
+        )
+        # render_component catches all exceptions and returns an HTML comment
+        assert "Component rendering error" in html
+        assert "rmx.this_icon_does_not_exist_xyz" in html
         assert "TypeError" not in html
 
 
@@ -92,6 +112,7 @@ class TestLbIconExistsFilter:
     def test_valid_icon_returns_true(self):
         assert lb_icon_exists("rmx.heart") is True
 
+    @override_settings(DEBUG=False)
     def test_nonexistent_icon_returns_false(self):
         assert lb_icon_exists("rmx.this_icon_does_not_exist_xyz") is False
 
@@ -101,6 +122,7 @@ class TestLbIconExistsFilter:
     def test_none_returns_false(self):
         assert lb_icon_exists(None) is False
 
+    @override_settings(DEBUG=False)
     def test_missing_template_returns_false(self):
         """When get_template raises TemplateDoesNotExist, filter returns False."""
         with patch(
@@ -109,6 +131,7 @@ class TestLbIconExistsFilter:
         ):
             assert lb_icon_exists("rmx.heart") is False
 
+    @override_settings(DEBUG=False)
     def test_missing_template_logs_warning(self, caplog):
         """A missing icon logs a labb.icons warning instead of crashing."""
         with caplog.at_level(logging.WARNING, logger="labb.icons"):
@@ -119,6 +142,7 @@ class TestLbIconExistsFilter:
                 lb_icon_exists("rmx.heart")
         assert any("rmx.heart" in r.message for r in caplog.records)
 
+    @override_settings(DEBUG=False)
     def test_labbicons_not_installed_logs_different_warning(self, caplog):
         """When labbicons is not installed, the warning mentions the package."""
         with caplog.at_level(logging.WARNING, logger="labb.icons"):
@@ -132,3 +156,33 @@ class TestLbIconExistsFilter:
                 ):
                     lb_icon_exists("rmx.heart")
         assert any("labbicons" in r.message for r in caplog.records)
+
+    @override_settings(DEBUG=True)
+    def test_nonexistent_icon_raises_value_error_in_debug(self):
+        """DEBUG=True: a bad icon name raises ValueError with a clear message."""
+        with pytest.raises(ValueError, match="rmx.this_icon_does_not_exist_xyz"):
+            lb_icon_exists("rmx.this_icon_does_not_exist_xyz")
+
+    @override_settings(DEBUG=True)
+    def test_missing_template_raises_value_error_in_debug(self):
+        """DEBUG=True: when get_template raises TemplateDoesNotExist, ValueError is raised."""
+        with patch(
+            "labb.templatetags.lb_tags.get_template",
+            side_effect=TemplateDoesNotExist("cotton/lbi/rmx/heart.html"),
+        ):
+            with pytest.raises(ValueError, match="rmx.heart"):
+                lb_icon_exists("rmx.heart")
+
+    @override_settings(DEBUG=True)
+    def test_labbicons_not_installed_raises_with_install_hint_in_debug(self):
+        """DEBUG=True + labbicons missing: ValueError message mentions INSTALLED_APPS."""
+        with patch(
+            "labb.templatetags.lb_tags.get_template",
+            side_effect=TemplateDoesNotExist("cotton/lbi/rmx/heart.html"),
+        ):
+            with patch(
+                "labb.templatetags.lb_tags.apps.is_installed",
+                return_value=False,
+            ):
+                with pytest.raises(ValueError, match="labbicons"):
+                    lb_icon_exists("rmx.heart")

--- a/labb/tests/components/test_icon_rendering.py
+++ b/labb/tests/components/test_icon_rendering.py
@@ -1,0 +1,134 @@
+"""
+Tests for icon rendering error handling.
+
+Covers two failure modes:
+  1. Icon name that doesn't exist in labbicons
+  2. labbicons not installed (simulated by mocking get_template)
+
+NOTE: Rendering-based tests must be defined BEFORE pure unit tests in this file.
+Django's template engine is initialized lazily on first use; render_component adds
+the temp dir to settings before the first render_to_string call, which is how the
+engine picks it up.  Any test that calls Template() or get_template() before a
+render_component call would initialize the engine without that temp dir, breaking
+all subsequent render_component calls.
+"""
+
+import logging
+from unittest.mock import patch
+
+from django.template import TemplateDoesNotExist
+
+from labb.templatetags.lb_tags import lb_icon_exists
+
+from .test_base import ComponentTestBase
+
+# ---------------------------------------------------------------------------
+# Rendering integration tests (must come first — see module docstring)
+# ---------------------------------------------------------------------------
+
+
+class TestIconRenderingGracefulDegradation(ComponentTestBase):
+    """Integration tests: components with bad icon names must not raise cryptic errors."""
+
+    def test_button_with_valid_icon_renders_svg(self):
+        """A button with a valid icon name renders the SVG."""
+        html = self.render_component(
+            "button",
+            slot_content="Click me",
+            **{"icon": "rmx.heart"},
+        )
+        assert "<button" in html
+        assert "<svg" in html
+
+    def test_button_with_nonexistent_icon_renders_without_crash(self):
+        """A button with a bad icon name renders the button; the icon is silently skipped."""
+        html = self.render_component(
+            "button",
+            slot_content="Click me",
+            **{"icon": "rmx.this_icon_does_not_exist_xyz"},
+        )
+        assert "<button" in html
+        assert "Click me" in html
+        assert "<svg" not in html
+
+    def test_alert_with_nonexistent_icon_renders_without_crash(self):
+        html = self.render_component(
+            "alert",
+            slot_content="Something happened",
+            **{"icon": "rmx.this_icon_does_not_exist_xyz"},
+        )
+        assert "alert" in html
+        assert "Something happened" in html
+        assert "<svg" not in html
+
+    def test_kbd_with_nonexistent_icon_renders_without_crash(self):
+        html = self.render_component(
+            "kbd",
+            slot_content="Ctrl",
+            **{"icon": "rmx.this_icon_does_not_exist_xyz"},
+        )
+        assert "<kbd" in html
+        assert "<svg" not in html
+
+    def test_nonexistent_icon_does_not_raise_type_error(self):
+        """The cryptic 'cannot unpack non-iterable NoneType object' must not surface."""
+        html = self.render_component(
+            "button",
+            slot_content="X",
+            **{"icon": "rmx.this_icon_does_not_exist_xyz"},
+        )
+        assert "cannot unpack non-iterable NoneType" not in html
+        assert "TypeError" not in html
+
+
+# ---------------------------------------------------------------------------
+# lb_icon_exists filter unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestLbIconExistsFilter:
+    """Unit tests for the lb_icon_exists filter (called as a plain Python function)."""
+
+    def test_valid_icon_returns_true(self):
+        assert lb_icon_exists("rmx.heart") is True
+
+    def test_nonexistent_icon_returns_false(self):
+        assert lb_icon_exists("rmx.this_icon_does_not_exist_xyz") is False
+
+    def test_empty_string_returns_false(self):
+        assert lb_icon_exists("") is False
+
+    def test_none_returns_false(self):
+        assert lb_icon_exists(None) is False
+
+    def test_missing_template_returns_false(self):
+        """When get_template raises TemplateDoesNotExist, filter returns False."""
+        with patch(
+            "labb.templatetags.lb_tags.get_template",
+            side_effect=TemplateDoesNotExist("cotton/lbi/rmx/heart.html"),
+        ):
+            assert lb_icon_exists("rmx.heart") is False
+
+    def test_missing_template_logs_warning(self, caplog):
+        """A missing icon logs a labb.icons warning instead of crashing."""
+        with caplog.at_level(logging.WARNING, logger="labb.icons"):
+            with patch(
+                "labb.templatetags.lb_tags.get_template",
+                side_effect=TemplateDoesNotExist("cotton/lbi/rmx/heart.html"),
+            ):
+                lb_icon_exists("rmx.heart")
+        assert any("rmx.heart" in r.message for r in caplog.records)
+
+    def test_labbicons_not_installed_logs_different_warning(self, caplog):
+        """When labbicons is not installed, the warning mentions the package."""
+        with caplog.at_level(logging.WARNING, logger="labb.icons"):
+            with patch(
+                "labb.templatetags.lb_tags.get_template",
+                side_effect=TemplateDoesNotExist("cotton/lbi/rmx/heart.html"),
+            ):
+                with patch(
+                    "labb.templatetags.lb_tags.apps.is_installed",
+                    return_value=False,
+                ):
+                    lb_icon_exists("rmx.heart")
+        assert any("labbicons" in r.message for r in caplog.records)


### PR DESCRIPTION
## handle-uninstalled-labbicons-pckg-and-unresolved-icons

No description provided

**Release:** v0.4.3
**Branch:** `fix/36-handle-uninstalled-labbicons-pckg-and-unresolved-icons`

Closes #81
