### PR TITLE
chore: swicth to github-managed release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,15 @@
+changelog:
+  exclude:
+    labels:
+      - release
+      - release-item
+  categories:
+    - title: "Features"
+      labels:
+        - feat
+    - title: "Bug Fixes"
+      labels:
+        - fix
+    - title: "Maintenance"
+      labels:
+        - chore

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -324,25 +324,10 @@ jobs:
             PRERELEASE_FLAG="--prerelease"
           fi
 
-          # Create the release with GitHub CLI
+          # Create the release with GitHub CLI (auto-generates notes from PRs/commits)
           gh release create "$TAG_NAME" \
             --title "Release $TAG_NAME" \
-            --notes "## Release $TAG_NAME
-
-          ### Installation
-          \`\`\`bash
-          # Core UI components
-          pip install labbui==$VERSION
-
-          # Optional packages
-          pip install labbicons==$VERSION  # Icon components
-          pip install labbdocs==$VERSION   # Documentation
-          pip install labbstart==$VERSION  # Project starter CLI
-          \`\`\`
-
-          ### Documentation
-          - [Documentation](https://labb.io/)
-          - [GitHub Repository](https://github.com/labbhq/labb)" \
+            --generate-notes \
             $PRERELEASE_FLAG
 
           echo "✅ GitHub release created"


### PR DESCRIPTION
## swicth-to-github-manage-release-notes

No description provided

**Release:** v0.4.4
**Branch:** `chore/39-swicth-to-github-manage-release-notes`

Closes #97
