### PR TITLE
Fix uv init layout and sync preview

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -38,7 +38,7 @@ jobs:
           virtualenvs-in-project: true
 
       - name: Install UV
-        run: irm https://astral.sh/uv/install.ps1 | iex
+        run: irm https://astral.sh/uv/0.12.3/install.ps1 | iex
         shell: pwsh
 
       - name: Add UV to PATH

--- a/.github/workflows/test-and-coverage.yml
+++ b/.github/workflows/test-and-coverage.yml
@@ -39,7 +39,7 @@ jobs:
           virtualenvs-in-project: true
 
       - name: Install UV
-        run: curl -LsSf https://astral.sh/uv/install.sh | sh
+        run: curl -LsSf https://astral.sh/uv/0.12.3/install.sh | sh
 
       - name: Add UV to PATH
         run: echo "$HOME/.local/bin" >> $GITHUB_PATH

--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ If you want a **django component library** that feels like writing HTML — not 
 - [Community](#community)
 - [Documentation](#documentation)
 
+🚨 Please note that as labb has not yet reached v1, there might be occasions of breaking releases. I will try my best to minimise such releases but if they do happen, it would be for very good reasons and benefits.
+
+Please subscribe to our [newsletter](https://newsletter.labb.io/) to get updates (max of 2 newsletters per month).
+
 ## Why labb for your Django UI?
 
 Django templates are powerful, but building a consistent UI means repeating markup on every page. **labb components** feel like native HTML tags (`<c-lb.button>`, `<c-lb.card>`, `<c-lb.modal>`) so you get a coherent design system without leaving Django.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+🚨 Please read https://github.com/labbhq/labb/discussions/104 for updates on upcoming v0.5.0 release.
+
 ![labb welcome kit](docs/labbdocs/static/lbdocs/img/labb/labb_welcome_kit.jpg)
 
 # labb — Django UI Component Library
@@ -20,6 +22,8 @@ If you want a **django component library** that feels like writing HTML — not 
 - [FAQ](#django-component-library-faq)
 - [Community](#community)
 - [Documentation](#documentation)
+
+---
 
 🚨 Please note that as labb has not yet reached v1, there might be occasions of breaking releases. I will try my best to minimise such releases but if they do happen, it would be for very good reasons and benefits.
 

--- a/extras/start/labbstart/cli/handlers/new_handler.py
+++ b/extras/start/labbstart/cli/handlers/new_handler.py
@@ -265,9 +265,12 @@ def setup_uv_project(project_path: Path, django_version: str) -> bool:
 
     min_python = DJANGO_MIN_PYTHON.get(django_version, "3.10")
 
-    # Initialize uv project pinned to the minimum Python for this Django version
+    # Initialize uv project pinned to the minimum Python for this Django version.
+    # --no-package keeps uv's application layout; from uv 0.12 the default became a
+    # packaged src/ project, whose module name then collides with startproject's.
     if not run_command(
-        ["uv", "init", "--no-readme", "--python", min_python], cwd=project_path
+        ["uv", "init", "--no-readme", "--no-package", "--python", min_python],
+        cwd=project_path,
     ):
         return False
 


### PR DESCRIPTION
uv 0.12 changed `uv init` to create a packaged src/ project by default. The generated package name then collides with the Django project name, so `startproject` refuses it and `labbstart new` fails for anyone on uv 0.12+.

Passes `--no-package` to keep the application layout, and pins uv in CI so the next upstream default change is a deliberate bump.

Branched off main, so this also brings preview up to date ahead of release/0.5.0a1. Supersedes #107.