### PR TITLE
fix(docs): banner reappearing, and the icons sidebar

### DIFF
--- a/docs/labbdocs/content/icons/index.md
+++ b/docs/labbdocs/content/icons/index.md
@@ -5,6 +5,7 @@ title: Icons
 description: "Remix Icon pack for labbicons: 2000+ django-cotton icon components for Django, Tailwind CSS, and labb templates on labb.io."
 keywords: "remix icons django, labbicons rmx, django icon component, c-lbi remix"
 doc_show_toc: false
+doc_hide_drawer: true
 doc_links:
     - title: Icon guide
       url: /docs/guide/building-uis/icons/

--- a/docs/labbdocs/views.py
+++ b/docs/labbdocs/views.py
@@ -71,7 +71,7 @@ def _build_docs_context(
     return context
 
 
-@cache_control(max_age=1000, public=True)
+@cache_control(max_age=1000, private=True)
 def docs_view(request, doc_name, path=""):
     """
     Generic documentation view that handles documentation based on LABB_DOCS settings.


### PR DESCRIPTION
Both reproduced on preview.labb.io with Playwright.

**Banner came back after dismissing.** The server side was fine — dismissal is recorded in the session and the next render suppresses it. The problem was `docs_view` marking a session-dependent page `public`:

```python
@cache_control(max_age=1000, public=True)
```

With one dismissed session, the origin returned the banner roughly 1 request in 10. Those responses were `cf-cache-status: DYNAMIC` with no `age`, and `{cache:'no-store'}` fetches reproduced it, so neither Cloudflare nor the browser cache was doing it.

Now `private`. That costs nothing: `Vary: Cookie` plus a per-user `csrftoken` already made every response a unique shared-cache key, so `public` was buying no CDN caching while risking one visitor's page being served to another.

**Icons had the docs sidebar.** It uses `doc_layout: component`, which wraps `docs/base.html`, and that layout already honours `doc_hide_drawer` — the blog index uses exactly that to go full width. Icons never set it.

Verified locally: 10 requests across guide, blog and icons all stay dismissed; icons sidebar goes 320px → 0 with the drawer still reachable on mobile.

`doc_configs/icons.yaml` needs rebuilding in labbio (`build_docs icons`).