### PR TITLE
fix(labbdocs): let a new docs book register without editing shared code

### DIFF
--- a/docs/labbdocs/templatetags/docs_tags.py
+++ b/docs/labbdocs/templatetags/docs_tags.py
@@ -202,18 +202,15 @@ def doc_url(context, file_path, doc_name=None):
     """
     doc_name = doc_name or context.get("doc_name")
 
-    url_prefix_map = {
-        "ui": "/docs/ui",
-        "guide": "/docs/guide",
-        "icons": "/docs/icons",
-    }
+    doc_types = getattr(settings, "LABB_DOCS", {}).get("types", {})
 
-    if doc_name not in url_prefix_map:
+    if doc_name not in doc_types:
         raise ValueError(
             f"Invalid doc_name: {doc_name} when resolving doc_url for {file_path}"
         )
 
-    return resolve_file_path_to_url(file_path, url_prefix_map[doc_name])
+    url_prefix = doc_types[doc_name].get("url_prefix", f"/docs/{doc_name}")
+    return resolve_file_path_to_url(file_path, url_prefix)
 
 
 @register.simple_tag

--- a/docs/labbdocs/views.py
+++ b/docs/labbdocs/views.py
@@ -120,6 +120,12 @@ def docs_view(request, doc_name, path=""):
     # Get document info (without rendering)
     doc_info = renderer.get_doc_info(url_path)
 
+    if doc_info.get("error") and not serve_raw_markdown:
+        index_info = renderer.get_doc_info(f"{url_path}index/")
+        if not index_info.get("error"):
+            url_path = f"{url_path}index/"
+            doc_info = index_info
+
     # If there's an error loading the document, raise 404
     if doc_info.get("error"):
         raise Http404(f"Document not found: {doc_info['error']}")


### PR DESCRIPTION
doc_url raised on any book outside a hardcoded {ui, guide, icons} map, and docs_view could not resolve a folder whose index.md is its landing page.